### PR TITLE
fix(search-extra-space) : Fixed extra space for single word autocomplete

### DIFF
--- a/src/app/catalog/components/search-box/search-box.component.spec.ts
+++ b/src/app/catalog/components/search-box/search-box.component.spec.ts
@@ -1,4 +1,5 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed, fakeAsync, inject } from '@angular/core/testing';
+
 import { ComponentFixtureAutoDetect } from '@angular/core/testing';
 
 import { SharedModule } from './../../../shared';
@@ -12,12 +13,14 @@ import { DebugElement } from '@angular/core';
 import { of } from 'rxjs';
 import { NotificationService } from '../../../core/services/notification/notification.service';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { WrappedCollection } from '../../../core/models/wrapped-collection';
 
 describe('SearchBoxComponent', () => {
   let component: SearchBoxComponent;
   let fixture: ComponentFixture<SearchBoxComponent>;
   let inputTextFieldDe: DebugElement;
   let inputTextFieldEl: HTMLInputElement;
+  let apiInfoService: ApiInfoService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -32,8 +35,25 @@ describe('SearchBoxComponent', () => {
     component = fixture.componentInstance;
     inputTextFieldDe = fixture.debugElement.query(By.css('.search-input-box'));
     inputTextFieldEl = inputTextFieldDe.nativeElement;
-    fixture.detectChanges();
+    apiInfoService = TestBed.get(ApiInfoService);
+    const suggestions = new WrappedCollection();
+    suggestions.items = ['word1', 'word2', 'hello world'];
+    suggestions.totalCount = suggestions.items.length;
+    spyOn(apiInfoService, 'autoComplete').and.returnValue(of(suggestions));
   });
+  // helper methods
+  function sendInput(text: string) {
+    component.myControl.setValue(text);
+    let inputElement: HTMLInputElement;
+    inputElement = fixture.nativeElement.querySelector('input');
+    inputElement.focus();
+    inputElement.value = text;
+    inputElement.dispatchEvent(new Event('input'));
+    inputElement.dispatchEvent(new Event('focusin'));
+    inputElement.dispatchEvent(new Event('keydown'));
+    fixture.detectChanges();
+    return fixture.whenStable();
+  }
 
   it('should create', () => {
     expect(component).toBeTruthy();
@@ -42,4 +62,19 @@ describe('SearchBoxComponent', () => {
   it('should create textbox to be initially be empty', () => {
     expect(inputTextFieldEl.value).toBe('');
   });
+
+  it('should fetch suggestions when textbox value changes', async(() => {
+    const text = 'hello';
+    let suggestions: string[];
+    component.filteredOptions$.subscribe(s => {
+      suggestions = s;
+    });
+    sendInput(text).then(() => {
+      expect(apiInfoService.autoComplete).toHaveBeenCalledWith(text);
+      expect(suggestions).toBeDefined();
+      expect(suggestions).toEqual(['word1', 'word2', 'hello world']);
+    });
+  }));
+
+  it('should add the selected suggestions in to the search box', () => {});
 });

--- a/src/app/catalog/components/search-box/search-box.component.spec.ts
+++ b/src/app/catalog/components/search-box/search-box.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed, fakeAsync, inject } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ComponentFixtureAutoDetect } from '@angular/core/testing';
 

--- a/src/app/catalog/components/search-box/search-box.component.ts
+++ b/src/app/catalog/components/search-box/search-box.component.ts
@@ -62,13 +62,13 @@ export class SearchBoxComponent implements OnInit {
       keyword = searchPhrase;
     } else {
       // Multiple words
-      prefix = searchPhrase.substr(0, middlePoint);
+      prefix = searchPhrase.substr(0, middlePoint) + SPACE;
       keyword = searchPhrase.substr(middlePoint + 1);
     }
 
     return this.service.autoComplete(keyword).pipe(
       // Prefix the single word with the rest of the phrase
-      map(suggestions => suggestions.items.map(s => prefix + SPACE + s)),
+      map(suggestions => suggestions.items.map(s => prefix + s)),
       // if no search results, the return the orginal phrase
       map(suggestions => (suggestions.length === 0 ? [value] : suggestions)),
       catchError(error => {

--- a/src/app/core/models/wrapped-collection.ts
+++ b/src/app/core/models/wrapped-collection.ts
@@ -1,4 +1,4 @@
 export class WrappedCollection<T> {
   items: Array<T> = [];
-  totalCount: Number;
+  totalCount: number;
 }


### PR DESCRIPTION
This PR addresses issues #15 
- Added a test case to capture the space issue
- Fixed the prefix of space only when there are multiple words in the text box. 
